### PR TITLE
Bugfix: Making it possible to set extra properties for AV/Media heartbeats

### DIFF
--- a/piano-analytics/src/main/java/io/piano/android/analytics/MediaHelper.kt
+++ b/piano-analytics/src/main/java/io/piano/android/analytics/MediaHelper.kt
@@ -121,8 +121,8 @@ class MediaHelper internal constructor(
      * @return this [MediaHelper] instance
      */
     @Suppress("unused", "MemberVisibilityCanBePrivate") // Public API.
-    fun setExtraProps(extraProps: Array<out Property>) = apply {
-        this.extraProps = extraProps
+    fun setExtraProps(vararg extraProps: Property): MediaHelper = apply {
+        this.extraProps = extraProps.copyOf()
     }
 
     /**


### PR DESCRIPTION
We had the problem with the SDK before that all our heartbeat events were missing all of the av insights standard + custom properties like the `av_content_x` - Properties.

This PR is fixing this by:
* Adding a field to the `Media` - class to store the `extraProps` - map + making it accessible.
* Using that field in the runnables for the heartbeats in `AVRunnable` to pass the extraProps instead of `null` as it was before.