### PR TITLE
Fix: Setting properties "av_previous_position", "av_position" and "av_duration" correctly

### DIFF
--- a/piano-analytics/src/main/java/io/piano/android/analytics/MediaHelper.kt
+++ b/piano-analytics/src/main/java/io/piano/android/analytics/MediaHelper.kt
@@ -514,9 +514,9 @@ class MediaHelper internal constructor(
     internal fun buildEvent(eventName: String, addOptions: Boolean = false, vararg properties: Property): Event {
         val avProperties = if (addOptions) {
             setOf(
-                Property(PropertyName("av_previous_position"), 0),
-                Property(PropertyName("av_position"), 0),
-                Property(PropertyName("av_duration"), 0),
+                Property(PropertyName("av_previous_position"), previousCursorPositionMillis),
+                Property(PropertyName("av_position"), currentCursorPositionMillis),
+                Property(PropertyName("av_duration"), eventDurationMillis),
                 Property(PropertyName("av_previous_event"), previousEventName)
             ).also {
                 previousEventName = eventName


### PR DESCRIPTION
* The values for the properties `av_previous_position`, `av_position` and `av_duration` (coming from local private member variables `previousCursorPositionMillis`, `currentCursorPositionMillis` and `eventDurationMillis`) are modified correctly and quite often in the `MediaHelper` - class
* However, when creating an event with `options = true` (e. g. when creating a `seek` - event), these values were not used.
* This lead to sending always the value `0` for these properties in all events received at the Piano backend.
* This small fix sets the correct values while creating the event.